### PR TITLE
Make the timeout infinite for the gunicorn app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./app/qp/QikProp /QikProp
 ENV QPdir /QikProp
 
 # what's only needed for continuumio/miniconda3
-RUN apt-get update && \
+RUN apt-get --allow-releaseinfo-change update && \
     pip install --upgrade pip && \
     apt-get install -y --no-install-recommends npm && \
     # QikProp thigs for the ELF 32-bit LSB executable that it is
@@ -51,7 +51,7 @@ USER www
 EXPOSE 5001
 
 # Run in Exec form, can't be overriden
-ENTRYPOINT [ "gunicorn", "--bind", "0.0.0.0:5001", "covid_apis:app"]
+ENTRYPOINT [ "gunicorn", "--bind", "0.0.0.0:5001", "--timeout", "0", "covid_apis:app"]
 # Params to pass to ENTRYPOINT, and can be overriden when running containers
 CMD ["-w", "2", "--access-logfile", "/var/www/logs/access.log", "--error-logfile", "/var/www/logs/error.log"]
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     {%- block head %}
-        <title>COVID-19 Molecular Structure and Therapeutics Hub</title>
+        <title>MolSSI QikProp Webservice</title>
 
     {%- block metas %}
         <meta charset="UTF-8"/>
-        <meta name="description" content="COVID-19 Molecular Structure and Therapeutics Hub"/>
+        <meta name="description" content="QikProp (Yale Version) provided as a webservice through MolSSI"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     {%- endblock metas %}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,7 @@
 {% import "bootstrap/wtf.html" as wtf %}
 {% import "_macros.html" as macros %}
 
-{% block title %}COVID-19 Molecular Structure and Therapeutics Hub{% endblock %}
+{% block title %}MolSSI QikProp Webservice{% endblock %}
 
 {% block navbar %}
      {% include 'partials/navbar.html' %}

--- a/app/templates/partials/navbar.html
+++ b/app/templates/partials/navbar.html
@@ -1,7 +1,7 @@
 {% block navbar %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-2" role="navigation">
       <div class="container">
-          <a class="navbar-brand" href="{{ url_for('main.index') }}">COVID-19 Hub</a>
+          <a class="navbar-brand" href="{{ url_for('main.index') }}">MolSSI QikProp Service</a>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flask>=1.1.0
 flask_bootstrap
 flask_mail
 Flask-WTF
+WTForms<1.0.0
 flask_login
 flask_caching
 flask_cors

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask>=1.1.0
 flask_bootstrap
 flask_mail
 Flask-WTF
-WTForms<1.0.0
+WTForms<3.0.0
 flask_login
 flask_caching
 flask_cors


### PR DESCRIPTION
QikProp is run when someone submits the form on the page, that runs QikProp, but if they submit a huge file, it could take longer than the default `gunicorn` timeout for the request to process of 30 seconds, which crashes their page. 

The correct way to fix this is to spin off a worker to run the computation while the actual HTTP request finishes quickly, then eventually returns the computation. I'll be implementing in a different PR `celery` for the worker and`redis` for the minmal backend communicator.

The “I just need to fix this quickly” fix is just set the `gunicorn` time out to infinite, so this PR does the later while working on the former.