### PR TITLE
QikProp Run Through Celery Worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get --allow-releaseinfo-change update && \
     pip install --upgrade pip && \
     apt-get install -y --no-install-recommends npm && \
     # QikProp thigs for the ELF 32-bit LSB executable that it is
-    # Adding this here because I suspect its dangerous fore previous
+    # Adding this here because I suspect its dangerous before previous
     dpkg --add-architecture i386 && \
     apt-get update  && \
     apt-get install -y libgcc1:i386 tcsh && \
@@ -40,10 +40,15 @@ RUN cd app/static && \
     npm install && \
     rm -rf /var/lib/apt/lists/*
 
-RUN groupadd -g $GROUP_ID www  && \
+# Make the I/O directories for workers pre-mount (else it mounts as root)
+# Make the user who will be doing the ops
+# own everything in the dir by the user
+RUN mkdir /var/www/qpin /var/www/qpout && \
+    groupadd -g $GROUP_ID www  && \
     useradd -r -g www -s /bin/sh -u $USER_ID www  && \
     chown -R www:www /var/www
 
+# Become the user
 USER www
 
 
@@ -51,9 +56,10 @@ USER www
 EXPOSE 5001
 
 # Run in Exec form, can't be overriden
-ENTRYPOINT [ "gunicorn", "--bind", "0.0.0.0:5001", "--timeout", "0", "covid_apis:app"]
+ENTRYPOINT [ "gunicorn", "--bind", "0.0.0.0:5001", "--timeout", "300", "covid_apis:app"]
 # Params to pass to ENTRYPOINT, and can be overriden when running containers
 CMD ["-w", "2", "--access-logfile", "/var/www/logs/access.log", "--error-logfile", "/var/www/logs/error.log"]
 
 # can't override ENTRYPOINT shell form
 #ENTRYPOINT gunicorn --bind :5000 --access-logfile - --error-logfile - qcarchive_web:app
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from flask_caching import Cache
 from flask_cors import CORS
 from flask_mongoengine import MongoEngine
 from flask_admin import Admin
+from celery import Celery
 import logging
 
 logger = logging.getLogger(__name__)
@@ -87,3 +88,19 @@ def create_app(config_name):
 
     return app
 
+
+def make_celery(app):
+    celery = Celery(
+        app.import_name,
+        backend=app.config['CELERY_RESULT_BACKEND'],
+        broker=app.config['CELERY_BROKER_URL']
+    )
+    celery.conf.update(app.config)
+
+    class ContextTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/app/assets.py
+++ b/app/assets.py
@@ -13,6 +13,10 @@ def compile_assets(app):
                        filters='jsmin',
                        output='dist/js/main.min.js')
 
+    bundles['file_upload_progress'] = Bundle('src/js/file_upload_progress.js',
+                       filters='jsmin',
+                       output='dist/js/upload.min.js')
+
     bundles['ml_datasets_css'] = Bundle('src/scss/ml_datasets/ml_datasets_bootstrap4.scss',
                          depends='**/*.scss',
                          filters='libsass',

--- a/app/celery_utils.py
+++ b/app/celery_utils.py
@@ -1,0 +1,10 @@
+def init_celery(celery, app):
+    celery.conf.update(app.config)
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+QP_OUTPUT_TAR_NAME = "qp_data.tar.gz"
+SERVE_PATH = Path(".", "qpout").resolve()
+INBOUND_PATH = Path(".", "qpin").resolve()

--- a/app/factory.py
+++ b/app/factory.py
@@ -1,0 +1,15 @@
+from flask import Flask
+import os
+from .celery_utils import init_celery
+from . import create_app
+
+PKG_NAME = os.path.dirname(os.path.relpath(__file__)).split("/")[-1]
+
+
+def create_app_celery(config_name=PKG_NAME, **kwargs):
+    app = create_app(config_name)
+    if kwargs.get("celery"):
+        init_celery(kwargs.get("celery"), app)
+    from app.main import main
+    app.register_blueprint(main)
+    return app

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -11,13 +11,16 @@ from flask_wtf.file import FileAllowed, FileRequired, FileField
 class ProgramForm(FlaskForm):
     input_file = FileField("Input File", validators=[
         FileRequired(),
-        FileAllowed(['mae', 'maegz', 'mae.gz',  # Maestro Files
-                     'mol', 'molgz', 'sd', 'sd.gz', 'sdgz', 'sdf', 'sdf.gz', 'sdfgz',  # MDL Files
-                     'mol2',  # Mol2 files
-                     'pdb',  # PDB files
-                     'z'  # BOSS/MCPRO Z-matrix Files
-                     ], "Only Maestro, MDL, Mol2, PDB, or BOSS/MCPRO Z-matrix Files are allowed")
-    ])  # This list isn't really accurate for v3
+        FileAllowed(  # This list isn't really accurate for v3
+            ['mae', 'maegz', 'mae.gz',  # Maestro Files
+             'mol', 'molgz', 'sd', 'sd.gz', 'sdgz', 'sdf', 'sdf.gz', 'sdfgz',  # MDL Files
+             'mol2',  # Mol2 files
+             'pdb',  # PDB files
+             'z'  # BOSS/MCPRO Z-matrix Files
+             ], "Only Maestro, MDL, Mol2, PDB, or BOSS/MCPRO Z-matrix Files are allowed")
+        ],
+        id="input_file"
+    )
     fast = BooleanField(label="Fast Processing Mode")
     similar = IntegerField(label="Generate this number of most similar molecules relative to last processed",
                            default=20,
@@ -36,7 +39,7 @@ class ProgramForm(FlaskForm):
                                         validators=[Optional(), NumberRange(min=0)])
     molecule_upper_bound = IntegerField(label="hi:",
                                         validators=[Optional(), NumberRange(min=0)])
-    submit = SubmitField('Run QikProp!')
+    submit = SubmitField('Run QikProp!', id="submit")
 
     @classmethod
     def program_kwargs_map(cls):

--- a/app/main/hashing.py
+++ b/app/main/hashing.py
@@ -1,0 +1,26 @@
+import hashlib
+
+
+# Taken from https://flask.palletsprojects.com/en/2.0.x/patterns/requestchecksum/
+class ChecksumCalcStream(object):
+
+    def __init__(self, stream):
+        self._stream = stream
+        self._hash = hashlib.sha1()
+
+    def read(self, bytes):
+        rv = self._stream.read(bytes)
+        self._hash.update(rv)
+        return rv
+
+    def readline(self, size_hint):
+        rv = self._stream.readline(size_hint)
+        self._hash.update(rv)
+        return rv
+
+
+def generate_checksum(request):
+    env = request.environ
+    stream = ChecksumCalcStream(env['wsgi.input'])
+    env['wsgi.input'] = stream
+    return stream._hash

--- a/app/main/tasks.py
+++ b/app/main/tasks.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from shutil import rmtree, move
+import traceback
+from typing import Union
+
+from werkzeug.datastructures import FileStorage
+
+from app import celery
+from ..qp import run_qikprop
+from ..constants import QP_OUTPUT_TAR_NAME, INBOUND_PATH, SERVE_PATH
+
+
+def _generate_dir_and_file_paths(directory, checksum, filename):
+    target_dir = Path(directory, f"{checksum}").resolve()
+    target_file = target_dir / filename  # Yay Path operations
+    return target_dir, target_file
+
+
+@celery.task()
+def run_qikprop_worker(datafile: Union[Path, str], options: dict, checksum: str):
+    datafile = Path(datafile)  # Cast to Path
+    serve_directory, serve_file = _generate_dir_and_file_paths(SERVE_PATH, checksum, QP_OUTPUT_TAR_NAME)
+    # Don't double up the work
+    # Check does not work right now since tarballs are named QP_OUTPUT_TAR_NAME.{tarball hash}
+    #     Leaving here until improvements can be made
+    if serve_file.exists():
+        return
+
+    serve_directory.mkdir(parents=True, exist_ok=True)
+    try:
+        output_file = run_qikprop(datafile, datafile.name, options)
+        output_file_path = Path(output_file)
+        # Setup new location - Make the checksum directory
+
+        # Move the file with shutil. Path.rename causes issues cross filesystem
+        move(output_file_path, serve_file)
+        # Cleanup inbound staging directory
+        str_path = str(datafile)
+        if str(INBOUND_PATH) in str_path and checksum in str_path:
+            rmtree(datafile.parent)
+    except Exception:
+        e = serve_directory / "ErrorDetails.txt"
+        with e.open("w") as f:
+            f.write(traceback.format_exc())
+    return
+
+
+def inbound_staging(file: FileStorage, filename: str, checksum: str):
+    """Setup inbound file staging. Do this because FileStorage isn't serializable in Celery"""
+    inbound_directory, inbound_file = _generate_dir_and_file_paths(INBOUND_PATH, checksum, filename)
+    # Don't overwrite staging files
+    if inbound_file.exists():
+        return inbound_file
+    # Make the staging directory
+    inbound_directory.mkdir(parents=True, exist_ok=True)
+    # Save the file
+    file.save(str(inbound_file))
+    return inbound_file
+
+
+def serve_file(checksum):
+    """See if the files are ready yet"""
+    inbound_directory, _ = _generate_dir_and_file_paths(INBOUND_PATH, checksum, "junk.file")
+    serve_directory, serve_file_path = _generate_dir_and_file_paths(SERVE_PATH, checksum, QP_OUTPUT_TAR_NAME)
+    error_file = Path(serve_directory, "ErrorDetails.txt")
+    # Serve tarball if there
+    if serve_file_path.exists():
+        return serve_file_path
+    # serve the error file if there
+    elif error_file.exists():
+        return error_file
+    # Serve info about file in staging
+    elif inbound_directory.exists():
+        return "In Staging"
+    # Serve nothing
+    return
+
+
+def clear_output(checksum):
+    """Delete any existing output given a specific checksum"""
+    possible_tarball = serve_file(checksum)
+    if isinstance(possible_tarball, Path):
+        rmtree(possible_tarball.parent)
+        return True
+    return False
+

--- a/app/models/time_guess.py
+++ b/app/models/time_guess.py
@@ -1,0 +1,76 @@
+import datetime
+from .. import db
+from flask import request, current_app
+from flask_mongoengine import DoesNotExist
+
+DEFAULT_TRACKING_NAME = "LiveDefault"
+
+
+class TimeGuess(db.DynamicDocument):   # flexible schema, can have extra attributes
+    """
+    Stores average time per computation
+
+
+    Attributes
+    ----------
+    time_per_kb: float
+        time per kilobyte the operation took
+
+    total_ops: int
+        total number of operations
+
+    """
+
+    time_per_kb = db.FloatField()
+    total_ops = db.IntField()
+    tracking_name = db.StringField()
+
+    meta = {
+        'strict': True,     # allow extra fields
+        'indexes': [
+            "tracking_name",
+        ]
+    }
+
+    def __str__(self):
+        return 'Tracking Name: ' + str(self.tracking_name) \
+               + ', Time Per kB (s): ' + str(self.time_per_kb) \
+               + ', Total Number of measurements: ' + str(self.total_ops)
+
+
+def check_time_data(tracking_name=DEFAULT_TRACKING_NAME):
+
+    # Check if document exists
+    try:
+        time_data = db.timeguess.objects.get(tracking_name=tracking_name)
+    except DoesNotExist:
+        time_data = {"tracking_name": tracking_name,
+                     "total_ops": 1,
+                     "time_per_kb": 0
+                     }
+
+    return time_data
+
+
+def update_estimate(operation_time, filesize_kb, tracking_name=DEFAULT_TRACKING_NAME):
+    """
+
+    operation_time: int/float
+        in seconds of how long operation took
+    filesize_kb: float
+        Size of file in kb
+    tracking_name: str, default is whatever DEFAULT_TRACKING_NAME is set to in time_guess.py
+    """
+
+    time_data = check_time_data(tracking_name=tracking_name)
+    time_per_kb = time_data["time_per_kb"]
+    total_ops = time_data["total_ops"]
+
+    new_average = ((time_per_kb * total_ops) + (operation_time/filesize_kb)) / (total_ops + 1)
+
+    time_data["time_per_kb"] = new_average
+    time_data["total_ops"] += 1
+
+    time_guess = TimeGuess(**time_data)
+
+    time_guess.save()

--- a/app/templates/covid/upload_data_form.html
+++ b/app/templates/covid/upload_data_form.html
@@ -49,7 +49,7 @@
 {#        </form> #}
 
 <!--        Trial form based on parts-->
-        <form class="form form-horizontal" method="post" role="form" novalidate enctype="multipart/form-data">
+        <form class="form form-horizontal" method="post" role="form" novalidate enctype="multipart/form-data" id="qpform">
             {{ form.hidden_tag() }}
             {{ wtf.form_errors(form, hiddens="only") }}
 
@@ -98,6 +98,15 @@
 
     {% include 'message_dialog.html' %}
 
+    {% if hash is defined %}  <!-- Make sure hash exits before showing the details-->
+        <div class="mb-5">
+            <div class="row justify-content-center my-5">
+                <h3>Files will be at
+                    <a class='btn btn-link' href='/qpout/{{ hash }}'><h3>https://qikprop.molssi.org/qpout/{{ hash }}</h3></a></h3>
+            </div>
+        </div>
+    {% endif %}
+
 {% endblock %}
 
 
@@ -107,9 +116,9 @@
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.20/js/dataTables.bootstrap4.min.js"></script>
 
-    {% assets "ml_js" %}
-        <script type="text/javascript" src="{{ ASSET_URL }}"></script>
-    {% endassets %}
+<!--    {% assets "file_upload_progress" %}-->
+<!--        <script type="text/javascript" src="{{ ASSET_URL }}"></script>-->
+<!--    {% endassets %}-->
 
 
 {% endblock %}

--- a/covid_apis.py
+++ b/covid_apis.py
@@ -14,7 +14,7 @@ if os.environ.get('FLASK_COVERAGE'):
 import sys
 import click
 # from flask_migrate import Migrate, upgrade
-from app import create_app, db
+from app import create_app, db, make_celery
 import logging.config
 import yaml
 
@@ -26,6 +26,14 @@ with open('logging_config.yml', 'r') as file:
 logger = logging.getLogger(__name__)
 
 app = create_app(os.getenv('FLASK_CONFIG') or 'default')
+app.config.update(
+    # URL here is the name of the docker-compose service name for DNS resolution
+    # https://stackoverflow.com/a/54968946/10364409
+    CELERY_BROKER_URL='redis://redis:6379',
+    CELERY_RESULT_BACKEND='redis://redis:6379'
+)
+
+celery = make_celery(app)
 
 
 @app.cli.command()

--- a/covid_apis.py
+++ b/covid_apis.py
@@ -14,7 +14,8 @@ if os.environ.get('FLASK_COVERAGE'):
 import sys
 import click
 # from flask_migrate import Migrate, upgrade
-from app import create_app, db, make_celery
+from app import create_app, db, celery
+from app.factory import create_app_celery
 import logging.config
 import yaml
 
@@ -25,15 +26,9 @@ with open('logging_config.yml', 'r') as file:
 
 logger = logging.getLogger(__name__)
 
-app = create_app(os.getenv('FLASK_CONFIG') or 'default')
-app.config.update(
-    # URL here is the name of the docker-compose service name for DNS resolution
-    # https://stackoverflow.com/a/54968946/10364409
-    CELERY_BROKER_URL='redis://redis:6379',
-    CELERY_RESULT_BACKEND='redis://redis:6379'
-)
-
-celery = make_celery(app)
+# app = create_app(os.getenv('FLASK_CONFIG') or 'default')
+# Celery modular setup taken from: https://medium.com/@frassetto.stefano/flask-celery-howto-d106958a15fe
+app = create_app_celery(os.getenv('FLASK_CONFIG') or 'default', celery=celery)
 
 
 @app.cli.command()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,10 @@ services:
       - MONGO_URI=mongodb://covid_user:covid_pass@mongo_service:27017/covid_apis_db
     volumes:
       - ./docker_data/app-data:/var/www/logs
+      - ./docker_data/worker-data:/app/public
     depends_on:
       - mongo_service
+      - redis
     ports:
       - "5001:5001"
     networks:
@@ -44,6 +46,35 @@ services:
     volumes:
       - ./docker_data/mongodb-data:/data/db
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    networks:
+      - backend
+
+  redis:
+    # env_file: ".env"
+    image: "redis:5.0.4-stretch"
+    restart: unless-stopped
+    stop_grace_period: 3s
+    volumes:
+      - ./docker_data/redis-data:/data
+    networks:
+      - backend
+
+  celery_worker:
+    build: .
+    environment:
+      # set by a .env file (add to production)
+#      - FLASK_CONFIG=production
+      - FLASK_CONFIG=development
+      - MONGO_URI=mongodb://covid_user:covid_pass@mongo_service:27017/covid_apis_db
+    entrypoint: celery -A covid_apis.celery worker -B -l debug
+    command: ""
+    depends_on:
+      - redis
+    #env_file: .env
+    restart: unless-stopped
+    stop_grace_period: 3s
+    volumes:
+      - ./docker_data/worker-data:/app/public
     networks:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       - MONGO_URI=mongodb://covid_user:covid_pass@mongo_service:27017/covid_apis_db
     volumes:
       - ./docker_data/app-data:/var/www/logs
-      - ./docker_data/worker-data:/app/public
+      - qpout:/var/www/qpout
+      - qpin:/var/www/qpin
     depends_on:
       - mongo_service
       - redis
@@ -55,7 +56,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 3s
     volumes:
-      - ./docker_data/redis-data:/data
+      - redis:/data
     networks:
       - backend
 
@@ -74,7 +75,8 @@ services:
     restart: unless-stopped
     stop_grace_period: 3s
     volumes:
-      - ./docker_data/worker-data:/app/public
+      - qpout:/var/www/qpout
+      - qpin:/var/www/qpin
     networks:
       - backend
 
@@ -105,5 +107,10 @@ networks:
       driver: bridge
   backend:
       driver: bridge
+
+volumes:
+  qpout:
+  qpin:
+  redis:
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,7 @@ gunicorn
 
 # App-specific stuff
 pyyaml
+
+# Celery and redis
+celery
+redis


### PR DESCRIPTION
This commit overhauls the way the jobs are processed to be handled by asynchronous workers in Celery rather than than through the main Flask process when called by the user.

* Celery and Redis are enabled to handle task operations through the celery worker
* Files are now staged both for input and output
* A URL is provided for users to fetch their files when the job is complete. They are given a hash of the input file which is computed upon submission. This hash is then used as the ID for the computation.
* A bit of restructuring is done to offload work from the views.py file.
* Removed some references to the old Machine learning template this is based on. Could do alot more, but lets keep this PR down
* Enabled ability to clear output directory in case of error
* Returns are determined from both staging step and if there is an error file or not.